### PR TITLE
Version 5.0.0-beta2

### DIFF
--- a/.docs/README.hbs
+++ b/.docs/README.hbs
@@ -20,7 +20,7 @@ If you'd like to contribute please take a look at [contribution guide](CONTRIBUT
 
 You're reading the README for the master branch of serialport. You probably want to be looking at the README of our latest release. See our [change log](changelog.md) for what's new and our [upgrade guide](UPGRADE_GUIDE.md) for a walk through on what to look out for between major versions.
 
-- [`serialport@5.0.0-beta1` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/5.0.0-beta1/README.md) this is the latest `5.x` releases.
+- [`serialport@5.0.0-beta2` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/5.0.0-beta2/README.md) this is the latest `5.x` releases.
 - [`serialport@4.0.3` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/4.0.3/README.md) it is the latest `4.x` releases.
 - [`serialport@3.1.2` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/3.1.2/README.md) it is the latest `3.x` releases.
 - [`serialport@2.1.2` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/2.1.2/README.md) it was the last `2.x` release
@@ -175,7 +175,7 @@ npm rebuild --build-from-source
 
 Electron is a framework for creating cross-platform desktop applications. Electron comes with it's own version of the Node.js runtime.
 
-If you require `serialport` as a depednancy for an Electron project you need to compile it for the version of Electron you're using in your project.
+If you require `serialport` as a dependency for an Electron project you need to compile it for the version of Electron you're using in your project.
 
 When you first install `serialport` it will compile against the version of Node.js on your machine, not against the Node.js runtime bundled with Electron.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you'd like to contribute please take a look at [contribution guide](CONTRIBUT
 
 You're reading the README for the master branch of serialport. You probably want to be looking at the README of our latest release. See our [change log](changelog.md) for what's new and our [upgrade guide](UPGRADE_GUIDE.md) for a walk through on what to look out for between major versions.
 
-- [`serialport@5.0.0-beta1` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/5.0.0-beta1/README.md) this is the latest `5.x` releases.
+- [`serialport@5.0.0-beta2` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/5.0.0-beta2/README.md) this is the latest `5.x` releases.
 - [`serialport@4.0.3` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/4.0.3/README.md) it is the latest `4.x` releases.
 - [`serialport@3.1.2` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/3.1.2/README.md) it is the latest `3.x` releases.
 - [`serialport@2.1.2` docs are here](https://github.com/EmergingTechnologyAdvisors/node-serialport/blob/2.1.2/README.md) it was the last `2.x` release
@@ -205,7 +205,7 @@ npm rebuild --build-from-source
 
 Electron is a framework for creating cross-platform desktop applications. Electron comes with it's own version of the Node.js runtime.
 
-If you require `serialport` as a depednancy for an Electron project you need to compile it for the version of Electron you're using in your project.
+If you require `serialport` as a dependency for an Electron project you need to compile it for the version of Electron you're using in your project.
 
 When you first install `serialport` it will compile against the version of Node.js on your machine, not against the Node.js runtime bundled with Electron.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+Version 5.0.0-beta2
+-------------
+- [all] fixed a crash when pausing while reading thanks to @bminer and @baffo32 and others to debug and fix this
+- [all] ReadLineParser has been renamed to ReadlineParser to match worldwide convention
+- [windows] Fix flush behavior using PurgeComm fixing #962 via @samisaham
+- [windows] Remove read and write timeouts solving #781 via @giseburt
+- [docs] Electron build docs #965 via @chalkers
+- [docs] Spelling fixes via @Awk34
+- [docs] Update parser docs to be correct #970 via @jacobq
+- [notes] buffer-indexof is now completely compliant with latest node 6 buffer.indexOf because it's nice to have and we now use it on older nodes
+- [notes] dropped node 5 support, should still work but you shouldn't use it
+
 Version 4.0.3
 -------------
 - Switch to the lie promise library as it's smaller and mimics nodejs's promise closer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serialport",
-  "version": "5.0.0-beta1",
+  "version": "5.0.0-beta2",
   "description": "Node.js package to access serial ports. Welcome your robotic javascript overlords. Better yet, program them!",
   "author": {
     "name": "Chris Williams",
@@ -10,7 +10,7 @@
   "binary": {
     "module_name": "serialport",
     "module_path": "build/{configuration}/",
-    "host": "https://github.com/EmergingTechnologyAdvisors/node-serialport/releases/download/5.0.0-beta1"
+    "host": "https://github.com/EmergingTechnologyAdvisors/node-serialport/releases/download/5.0.0-beta2"
   },
   "main": "./lib/serialport",
   "repository": {


### PR DESCRIPTION
- [all] fixed a crash when pausing while reading thanks to @bminer and @baffo32 and others to debug and fix this
- [all] ReadLineParser has been renamed to ReadlineParser to match worldwide convention
- [windows] Fix flush behavior using PurgeComm fixing #962 via @samisaham
- [windows] Remove read and write timeouts solving #781 via @giseburt
- [docs] Electron build docs #965 via @chalkers
- [docs] Spelling fixes via @Awk34
- [docs] Update parser docs to be correct #970 via @jacobq
- [notes] buffer-indexof is now completely compliant with latest node 6 buffer.indexOf because it's nice to have and we now use it on older nodes
- [notes] dropped node 5 support, should still work but you shouldn't use it